### PR TITLE
Jraft metrics 0926

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/JRaftServer.java
@@ -274,7 +274,7 @@ public class JRaftServer {
                     .convertDurationsTo(TimeUnit.MILLISECONDS)
                     .setGroupName(groupName)
                     .build();
-            reporter.start(10, TimeUnit.SECONDS);
+            reporter.start(15, TimeUnit.SECONDS);
             
             machine.setNode(node);
             RouteTable.getInstance().updateConfiguration(groupName, configuration);

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/NacosMetersReporter.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/NacosMetersReporter.java
@@ -45,6 +45,8 @@ public class NacosMetersReporter extends ScheduledReporter {
     
     private String groupName;
     
+    private static final String PREFIX = "jraft_";
+    
     /**
      * Returns a new {@link Builder} for {@link NacosMetersReporter}.
      *
@@ -192,7 +194,7 @@ public class NacosMetersReporter extends ScheduledReporter {
         String metricsKey = key.replace("-", "_");
         if (metricsKey.equals(CoreMetricsConstant.PRE_VOTE)
                 || metricsKey.equals(CoreMetricsConstant.REQUEST_VOTE)) {
-            MetricsManager.gauge(metricsKey.concat("_count"),
+            MetricsManager.gauge(PREFIX + metricsKey.concat("_count"),
                             CoreMetricsConstant.GROUP_NAME, groupName)
                     .getAndAdd(value.getCount());
         }
@@ -202,7 +204,7 @@ public class NacosMetersReporter extends ScheduledReporter {
         String metricsKey = key.replace("-", "_");
         if (metricsKey.equals(CoreMetricsConstant.APPEND_LOGS_COUNT)
                 || metricsKey.equals(CoreMetricsConstant.REPLICATE_ENTRIES_COUNT)) {
-            MetricsManager.gauge(metricsKey,
+            MetricsManager.gauge(PREFIX + metricsKey,
                             CoreMetricsConstant.GROUP_NAME, groupName)
                     .set(value.getCount());
         }
@@ -212,7 +214,7 @@ public class NacosMetersReporter extends ScheduledReporter {
         String metricsKey = key.replace("-", "_");
         if (metricsKey.equals(CoreMetricsConstant.NEXT_INDEX)
                 || metricsKey.equals(CoreMetricsConstant.LOG_LAGS)) {
-            MetricsManager.gauge(metricsKey,
+            MetricsManager.gauge(PREFIX + metricsKey,
                             CoreMetricsConstant.GROUP_NAME, groupName)
                     .set(Long.parseLong(value.getValue().toString()));
         }

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/NacosMetersReporter.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/NacosMetersReporter.java
@@ -190,11 +190,9 @@ public class NacosMetersReporter extends ScheduledReporter {
     
     private void reportTimer(String key, Timer value) {
         String metricsKey = key.replace("-", "_");
-        if (metricsKey.equals(CoreMetricsConstant.APPEND_LOGS)
-                || metricsKey.equals(CoreMetricsConstant.REPLICATE_ENTRIES)
-                || metricsKey.equals(CoreMetricsConstant.PRE_VOTE)
+        if (metricsKey.equals(CoreMetricsConstant.PRE_VOTE)
                 || metricsKey.equals(CoreMetricsConstant.REQUEST_VOTE)) {
-            MetricsManager.gauge(metricsKey.concat("_total"),
+            MetricsManager.gauge(metricsKey.concat("_count"),
                             CoreMetricsConstant.GROUP_NAME, groupName)
                     .getAndAdd(value.getCount());
         }

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/NacosMetersReporter.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/raft/utils/NacosMetersReporter.java
@@ -190,10 +190,10 @@ public class NacosMetersReporter extends ScheduledReporter {
     
     private void reportTimer(String key, Timer value) {
         String metricsKey = key.replace("-", "_");
-        if (metricsKey.equals(CoreMetricsConstant.APPEND_LOGS) ||
-                metricsKey.equals(CoreMetricsConstant.REPLICATE_ENTRIES) ||
-                metricsKey.equals(CoreMetricsConstant.PRE_VOTE) ||
-                metricsKey.equals(CoreMetricsConstant.REQUEST_VOTE)) {
+        if (metricsKey.equals(CoreMetricsConstant.APPEND_LOGS)
+                || metricsKey.equals(CoreMetricsConstant.REPLICATE_ENTRIES)
+                || metricsKey.equals(CoreMetricsConstant.PRE_VOTE)
+                || metricsKey.equals(CoreMetricsConstant.REQUEST_VOTE)) {
             MetricsManager.gauge(metricsKey.concat("_total"),
                             CoreMetricsConstant.GROUP_NAME, groupName)
                     .getAndAdd(value.getCount());
@@ -202,8 +202,8 @@ public class NacosMetersReporter extends ScheduledReporter {
     
     private void reportHistogram(String key, Histogram value) {
         String metricsKey = key.replace("-", "_");
-        if (metricsKey.equals(CoreMetricsConstant.APPEND_LOGS_COUNT) ||
-                metricsKey.equals(CoreMetricsConstant.REPLICATE_ENTRIES_COUNT)) {
+        if (metricsKey.equals(CoreMetricsConstant.APPEND_LOGS_COUNT)
+                || metricsKey.equals(CoreMetricsConstant.REPLICATE_ENTRIES_COUNT)) {
             MetricsManager.gauge(metricsKey,
                             CoreMetricsConstant.GROUP_NAME, groupName)
                     .set(value.getCount());
@@ -212,8 +212,8 @@ public class NacosMetersReporter extends ScheduledReporter {
 
     private void reportGauge(String key, Gauge value) {
         String metricsKey = key.replace("-", "_");
-        if (metricsKey.equals(CoreMetricsConstant.NEXT_INDEX) ||
-                metricsKey.equals(CoreMetricsConstant.LOG_LAGS)) {
+        if (metricsKey.equals(CoreMetricsConstant.NEXT_INDEX)
+                || metricsKey.equals(CoreMetricsConstant.LOG_LAGS)) {
             MetricsManager.gauge(metricsKey,
                             CoreMetricsConstant.GROUP_NAME, groupName)
                     .set(Long.parseLong(value.getValue().toString()));

--- a/metrics/src/main/java/com/alibaba/nacos/metrics/manager/CoreMetricsConstant.java
+++ b/metrics/src/main/java/com/alibaba/nacos/metrics/manager/CoreMetricsConstant.java
@@ -39,6 +39,46 @@ public class CoreMetricsConstant {
     public static final String NACOS_GRPC_REQUEST_COUNT = "nacos_grpc_request_count";
     
     /**
+     * metrics name.
+     */
+    public static final String APPEND_LOGS_COUNT = "append_logs_count";
+    
+    /**
+     * metrics name.
+     */
+    public static final String REPLICATE_ENTRIES_COUNT = "replicate_entries_count";
+    
+    /**
+     * metrics name.
+     */
+    public static final String NEXT_INDEX = "next_index";
+    
+    /**
+     * metrics name.
+     */
+    public static final String LOG_LAGS = "log_lags";
+    
+    /**
+     * metrics name.
+     */
+    public static final String APPEND_LOGS = "append_logs";
+    
+    /**
+     * metrics name.
+     */
+    public static final String REPLICATE_ENTRIES = "replicate_entries";
+    
+    /**
+     * metrics name.
+     */
+    public static final String PRE_VOTE = "pre_vote";
+    
+    /**
+     * metrics name.
+     */
+    public static final String REQUEST_VOTE = "request_vote";
+    
+    /**
      * metrics tag key.
      */
     public static final String MODULE = "module";
@@ -47,6 +87,11 @@ public class CoreMetricsConstant {
      * metrics tag key.
      */
     public static final String NAME = "name";
+    
+    /**
+     * metrics tag key.
+     */
+    public static final String GROUP_NAME = "group_name";
     
     /**
      * metrics tag value.

--- a/metrics/src/main/java/com/alibaba/nacos/metrics/manager/CoreMetricsConstant.java
+++ b/metrics/src/main/java/com/alibaba/nacos/metrics/manager/CoreMetricsConstant.java
@@ -61,16 +61,6 @@ public class CoreMetricsConstant {
     /**
      * metrics name.
      */
-    public static final String APPEND_LOGS = "append_logs";
-    
-    /**
-     * metrics name.
-     */
-    public static final String REPLICATE_ENTRIES = "replicate_entries";
-    
-    /**
-     * metrics name.
-     */
     public static final String PRE_VOTE = "pre_vote";
     
     /**


### PR DESCRIPTION
As we all knowned, nacos use JRaft to implement cp mode and has not collect any metrics from JRaft. 
This PR is aimd to improve that blank for nacos.

I add eight metrics, such as, append_logs_count which means the number of RAFT logs written.

All metrics is below:
append_logs_count                                 :**the total number of RAFT logs written.**
replicate_entries_count                          :**the total number of replicate logs from leader to folllower.**
next_index                                                :**the log index that is coping.**
log_lags                                                    :**the total numer of delay log.**
pre_vote_count                                        :**the total number of pre vote times.**
request_vote_count                                 :**the total number of request vote times.**