### PR TITLE
add distro metrics in core module.

### DIFF
--- a/core/src/main/java/com/alibaba/nacos/core/distributed/distro/task/execute/AbstractDistroExecuteTask.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/distro/task/execute/AbstractDistroExecuteTask.java
@@ -26,6 +26,8 @@ import com.alibaba.nacos.core.distributed.distro.entity.DistroKey;
 import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecord;
 import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecordsHolder;
 import com.alibaba.nacos.core.utils.Loggers;
+import com.alibaba.nacos.metrics.manager.CoreMetricsConstant;
+import com.alibaba.nacos.metrics.manager.MetricsManager;
 
 /**
  * Abstract distro execute task.
@@ -120,6 +122,11 @@ public abstract class AbstractDistroExecuteTask extends AbstractExecuteTask {
         public void onSuccess() {
             DistroRecord distroRecord = DistroRecordsHolder.getInstance().getRecord(getDistroKey().getResourceType());
             distroRecord.syncSuccess();
+            MetricsManager.counter(CoreMetricsConstant.DISTRO_SYNC,
+                    CoreMetricsConstant.RESOURCE_TYPE, distroKey.getResourceType(),
+                    CoreMetricsConstant.TARGET_SERVER, distroKey.getTargetServer(),
+                    CoreMetricsConstant.SUCCESS, CoreMetricsConstant.TRUE)
+                    .increment();
             Loggers.DISTRO.info("[DISTRO-END] {} result: true", getDistroKey().toString());
         }
         
@@ -127,6 +134,11 @@ public abstract class AbstractDistroExecuteTask extends AbstractExecuteTask {
         public void onFailed(Throwable throwable) {
             DistroRecord distroRecord = DistroRecordsHolder.getInstance().getRecord(getDistroKey().getResourceType());
             distroRecord.syncFail();
+            MetricsManager.counter(CoreMetricsConstant.DISTRO_SYNC,
+                            CoreMetricsConstant.RESOURCE_TYPE, distroKey.getResourceType(),
+                            CoreMetricsConstant.TARGET_SERVER, distroKey.getTargetServer(),
+                            CoreMetricsConstant.SUCCESS, CoreMetricsConstant.FALSE)
+                    .increment();
             if (null == throwable) {
                 Loggers.DISTRO.info("[DISTRO-END] {} result: false", getDistroKey().toString());
             } else {

--- a/core/src/main/java/com/alibaba/nacos/core/distributed/distro/task/verify/DistroVerifyExecuteTask.java
+++ b/core/src/main/java/com/alibaba/nacos/core/distributed/distro/task/verify/DistroVerifyExecuteTask.java
@@ -23,6 +23,8 @@ import com.alibaba.nacos.core.distributed.distro.entity.DistroData;
 import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecord;
 import com.alibaba.nacos.core.distributed.distro.monitor.DistroRecordsHolder;
 import com.alibaba.nacos.core.utils.Loggers;
+import com.alibaba.nacos.metrics.manager.CoreMetricsConstant;
+import com.alibaba.nacos.metrics.manager.MetricsManager;
 
 import java.util.List;
 
@@ -77,6 +79,11 @@ public class DistroVerifyExecuteTask extends AbstractExecuteTask {
         
         @Override
         public void onSuccess() {
+            MetricsManager.counter(CoreMetricsConstant.DISTRO_VERIFY,
+                            CoreMetricsConstant.RESOURCE_TYPE, resourceType,
+                            CoreMetricsConstant.TARGET_SERVER, targetServer,
+                            CoreMetricsConstant.SUCCESS, CoreMetricsConstant.TRUE)
+                    .increment();
             if (Loggers.DISTRO.isDebugEnabled()) {
                 Loggers.DISTRO.debug("[DISTRO] verify data for type {} to {} success", resourceType, targetServer);
             }
@@ -86,6 +93,11 @@ public class DistroVerifyExecuteTask extends AbstractExecuteTask {
         public void onFailed(Throwable throwable) {
             DistroRecord distroRecord = DistroRecordsHolder.getInstance().getRecord(resourceType);
             distroRecord.verifyFail();
+            MetricsManager.counter(CoreMetricsConstant.DISTRO_VERIFY,
+                            CoreMetricsConstant.RESOURCE_TYPE, resourceType,
+                            CoreMetricsConstant.TARGET_SERVER, targetServer,
+                            CoreMetricsConstant.SUCCESS, CoreMetricsConstant.FALSE)
+                    .increment();
             if (Loggers.DISTRO.isDebugEnabled()) {
                 Loggers.DISTRO
                         .debug("[DISTRO-FAILED] verify data for type {} to {} failed.", resourceType, targetServer,

--- a/metrics/src/main/java/com/alibaba/nacos/metrics/manager/CoreMetricsConstant.java
+++ b/metrics/src/main/java/com/alibaba/nacos/metrics/manager/CoreMetricsConstant.java
@@ -39,6 +39,16 @@ public class CoreMetricsConstant {
     public static final String NACOS_GRPC_REQUEST_COUNT = "nacos_grpc_request_count";
     
     /**
+     * metrics name.
+     */
+    public static final String DISTRO_VERIFY = "distro_verify";
+    
+    /**
+     * metrics name.
+     */
+    public static final String DISTRO_SYNC = "distro_sync";
+    
+    /**
      * metrics tag key.
      */
     public static final String MODULE = "module";
@@ -47,6 +57,21 @@ public class CoreMetricsConstant {
      * metrics tag key.
      */
     public static final String NAME = "name";
+    
+    /**
+     * metrics tag key.
+     */
+    public static final String RESOURCE_TYPE = "resourceType";
+    
+    /**
+     * metrics tag key.
+     */
+    public static final String TARGET_SERVER = "targetServer";
+    
+    /**
+     * metrics tag key.
+     */
+    public static final String SUCCESS = "success";
     
     /**
      * metrics tag value.
@@ -62,4 +87,14 @@ public class CoreMetricsConstant {
      * metrics tag value.
      */
     public static final String LONG_CONNECTION = "longConnection";
+    
+    /**
+     * metrics tag value.
+     */
+    public static final String TRUE = "ture";
+    
+    /**
+     * metrics tag value.
+     */
+    public static final String FALSE = "false";
 }


### PR DESCRIPTION
This pr is aimed to add distro metrics for core module.
Here is the metrics below:
1. distro_verify{resource_type=resourceType, target_server=targetServer, success=true}. It counts verifySuccess times.
2. distro_verify{resource_type=resourceType, target_server=targetServer, success=false}. It counts verifyFailed times.
3. distro_sync{resource_type=resourceType, target_server=targetServer, success=true}. It counts syncSuccess times.
4. distro_sync{resource_type=resourceType, target_server=targetServer, success=false}. It counts syncFailed times.